### PR TITLE
feat: hotel-service Availability API의 비동기 로직 변경, DB 조회 로직 최적화 (#26)

### DIFF
--- a/service/hotel-service/src/main/java/dev/muho/hotel/controller/AvailabilityController.java
+++ b/service/hotel-service/src/main/java/dev/muho/hotel/controller/AvailabilityController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * 객실 이용 가능 여부(Availability) 조회를 위한 컨트롤러입니다.
@@ -22,12 +23,16 @@ public class AvailabilityController {
 
     private final AvailabilityService availabilityService;
 
+    private final Executor asyncTaskExecutor;
+
     @GetMapping("/api/v1/hotels/{hotelId}/availability")
     public CompletableFuture<ResponseEntity<AvailabilityResponse>> getAvailability(
             @PathVariable Long hotelId,
             @Valid @ModelAttribute AvailabilityRequest request) {
 
-        return availabilityService.checkAvailabilityAsync(hotelId, request)
-                .thenApply(ResponseEntity::ok);
+        return CompletableFuture.supplyAsync(() -> {
+            AvailabilityResponse response = availabilityService.checkAvailability(hotelId, request);
+            return ResponseEntity.ok(response);
+        }, asyncTaskExecutor);
     }
 }

--- a/service/hotel-service/src/main/java/dev/muho/hotel/domain/Hotel.java
+++ b/service/hotel-service/src/main/java/dev/muho/hotel/domain/Hotel.java
@@ -63,4 +63,8 @@ public class Hotel extends BaseTimeEntity {
     public void changeStatus(Status status) {
         this.status = status;
     }
+
+    public boolean isOnSale() {
+        return this.status == Status.ACTIVE;
+    }
 }

--- a/service/hotel-service/src/main/java/dev/muho/hotel/domain/RoomType.java
+++ b/service/hotel-service/src/main/java/dev/muho/hotel/domain/RoomType.java
@@ -76,4 +76,8 @@ public class RoomType extends BaseTimeEntity {
     public boolean validateCapacity(int numOfAdult, int numOfChildren) {
         return this.maxCapacity >= numOfAdult + numOfChildren;
     }
+
+    public boolean isOnSale() {
+        return this.status == Status.ACTIVE;
+    }
 }

--- a/service/hotel-service/src/main/java/dev/muho/hotel/repository/BaseRateRepository.java
+++ b/service/hotel-service/src/main/java/dev/muho/hotel/repository/BaseRateRepository.java
@@ -6,9 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 public interface BaseRateRepository extends JpaRepository<BaseRate, Long> {
     /** 특정 요금제에 대해, 주어진 날짜 목록에 해당하는 모든 기본 요금 정보를 조회합니다. */
     List<BaseRate> findByRatePlanAndDateIn(RatePlan ratePlan, List<LocalDate> dates);
+
+    List<BaseRate> findByRatePlanInAndDateIn(List<RatePlan> ratePlans, List<LocalDate> dates);
 }

--- a/service/hotel-service/src/main/java/dev/muho/hotel/repository/PriceAdjustmentRepository.java
+++ b/service/hotel-service/src/main/java/dev/muho/hotel/repository/PriceAdjustmentRepository.java
@@ -12,4 +12,7 @@ import java.util.List;
 public interface PriceAdjustmentRepository extends JpaRepository<PriceAdjustment, Long>, JpaSpecificationExecutor<PriceAdjustment> {
     @Query("SELECT pa FROM PriceAdjustment pa WHERE pa.ratePlan = :ratePlan AND pa.startDate <= :stayEnd AND pa.endDate >= :stayStart")
     List<PriceAdjustment> findActiveAdjustmentsForPlanInDateRange(RatePlan ratePlan, LocalDate stayStart, LocalDate stayEnd);
+
+    @Query("SELECT pa FROM PriceAdjustment pa WHERE pa.ratePlan IN :ratePlans AND pa.startDate <= :stayEnd AND pa.endDate >= :stayStart")
+    List<PriceAdjustment> findActiveAdjustmentsByRatePlanInDateRange(List<RatePlan> ratePlans, LocalDate stayStart, LocalDate stayEnd);
 }

--- a/service/hotel-service/src/main/java/dev/muho/hotel/repository/RoomInventoryRepository.java
+++ b/service/hotel-service/src/main/java/dev/muho/hotel/repository/RoomInventoryRepository.java
@@ -18,4 +18,6 @@ public interface RoomInventoryRepository extends JpaRepository<RoomInventory, Lo
      * 특정 객실 타입과 날짜에 해당하는 재고 정보를 조회합니다.
      */
     Optional<RoomInventory> findByRoomTypeAndDate(RoomType roomType, LocalDate date);
+
+    List<RoomInventory> findByRoomTypeInAndDateIn(List<RoomType> roomTypes, List<LocalDate> dates);
 }

--- a/service/hotel-service/src/main/java/dev/muho/hotel/repository/RoomTypeRepository.java
+++ b/service/hotel-service/src/main/java/dev/muho/hotel/repository/RoomTypeRepository.java
@@ -4,7 +4,11 @@ import dev.muho.hotel.domain.RoomType;
 import dev.muho.hotel.domain.Status;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface RoomTypeRepository extends JpaRepository<RoomType, Long> {
     Page<RoomType> findByHotelId(Long hotelId, Pageable pageable);
@@ -18,4 +22,8 @@ public interface RoomTypeRepository extends JpaRepository<RoomType, Long> {
 
     Page<RoomType> findByHotelIdAndStatus(
             Long hotelId, Status status, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"ratePlans"})
+    @Query("SELECT rt FROM RoomType rt WHERE rt.hotel.id = :hotelId")
+    List<RoomType> findByHotelIdWithRatePlans(Long hotelId);
 }

--- a/service/hotel-service/src/main/java/dev/muho/hotel/service/AvailabilityService.java
+++ b/service/hotel-service/src/main/java/dev/muho/hotel/service/AvailabilityService.java
@@ -17,40 +17,29 @@ import dev.muho.hotel.global.exception.HotelNotFoundException;
 import dev.muho.hotel.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * 호텔 객실 예약 가능성을 조회하는 서비스 클래스입니다.
+ * 객실 예약 가능 여부(Availability) 조회를 처리하는 서비스 클래스입니다.
  *
- * <p>이 서비스는 다음과 같은 주요 기능을 제공합니다:</p>
+ * <p>주요 기능:</p>
  * <ul>
- *   <li>특정 호텔의 예약 가능한 객실 타입 조회</li>
- *   <li>각 객실 타입별 재고 확인</li>
- *   <li>판매 가능한 요금제 필터링</li>
- *   <li>기본 요금 + 할인/할증 적용한 최종 가격 계산</li>
+ *   <li>호텔 및 객실 타입, 요금제, 재고, 가격 조정 데이터 조회</li>
+ *   <li>투숙 인원수에 맞는 객실 타입 필터링</li>
+ *   <li>숙박 기간 중 최소 재고량 확인</li>
+ *   <li>요금제 판매 조건 검증 (판매 기간, 예약 기간, 최소/최대 숙박일)</li>
+ *   <li>일별 기본 요금에 가격 조정(할인/할증) 적용하여 총 숙박비 계산</li>
+ *   <li>예약 가능한 객실 타입과 요금제를 응답 DTO로 변환</li>
  * </ul>
- *
- * <p>주요 비즈니스 로직:</p>
- * <ol>
- *   <li>호텔 정보 조회 및 유효성 검증</li>
- *   <li>투숙 인원수 기준 객실 타입 필터링</li>
- *   <li>각 객실 타입별 재고 확인 (숙박 기간 중 최소 재고량)</li>
- *   <li>요금제 판매 조건 확인 (판매 기간, 예약 기간, 최소/최대 숙박일)</li>
- *   <li>일별 기본 요금 + 가격 조정(할인/할증) 적용하여 총 숙박비 계산</li>
- * </ol>
- *
- * @author muho
- * @since 1.0
  */
 @Slf4j
 @Service
@@ -66,180 +55,130 @@ public class AvailabilityService {
     private final PriceAdjustmentRepository priceAdjustmentRepository;
 
     /**
-     * 지정된 조건에 따라 호텔의 예약 가능한 객실과 요금 정보를 조회합니다.
+     * 특정 호텔의 객실 예약 가능 여부를 조회합니다.
      *
-     * <p>이 메서드는 다음과 같은 순서로 처리됩니다:</p>
+     * <p>조회 로직:</p>
      * <ol>
-     *   <li>호텔 정보 조회 및 존재 여부 확인</li>
-     *   <li>호텔의 모든 객실 타입 조회</li>
-     *   <li>투숙 인원수 기준으로 수용 가능한 객실 타입 필터링</li>
-     *   <li>각 객실 타입별 예약 가능성 및 요금 계산</li>
-     *   <li>판매 가능한 요금제가 있는 객실 타입만 최종 결과에 포함</li>
+     *   <li>호텔 정보 조회 및 판매 여부 확인</li>
+     *   <li>투숙 인원수에 맞는 객실 타입 필터링</li>
+     *   <li>각 객실 타입별 재고 확인 (숙박 기간 중 최소 재고량)</li>
+     *   <li>요금제 판매 조건 확인 (판매 기간, 예약 기간, 최소/최대 숙박일)</li>
+     *   <li>일별 기본 요금 + 가격 조정(할인/할증) 적용하여 총 숙박비 계산</li>
+     *   <li>예약 가능한 객실 타입과 요금제를 응답 DTO로 변환</li>
      * </ol>
      *
-     * @param hotelId 조회할 호텔의 ID
-     * @param request 예약 가능성 조회 요청 객체
-     * @return 예약 가능한 객실 타입과 요금제 정보가 포함된 응답 객체
-     * @throws HotelNotFoundException 존재하지 않는 호텔 ID인 경우
+     * @param hotelId 조회할 호텔 ID
+     * @param request 조회 조건 (체크인/체크아웃 날짜, 투숙 인원수 등)
+     * @return 예약 가능한 객실 타입과 요금제를 포함한 응답 DTO
+     * @throws HotelNotFoundException 호텔 ID에 해당하는 호텔이 없는 경우
      */
-    public CompletableFuture<AvailabilityResponse> checkAvailabilityAsync(Long hotelId, AvailabilityRequest request) {
+    public AvailabilityResponse checkAvailability(Long hotelId, AvailabilityRequest request) {
         Hotel hotel = hotelRepository.findById(hotelId)
                 .orElseThrow(HotelNotFoundException::new);
 
-        List<CompletableFuture<AvailableRoomTypeDto>> futures = hotel.getRoomTypes().stream()
-                .filter(roomType -> roomType.validateCapacity(request.getAdults(), request.getChildren()))
-                .map(roomType -> toAvailableRoomTypeDtoAsync(roomType, request.getCheckInDate(), request.getCheckOutDate()))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
-
-        CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-
-        return allFutures.thenApply(v -> {
-            List<AvailableRoomTypeDto> availableRoomTypes = futures.stream()
-                    .map(CompletableFuture::join) // 각 Future의 결과를 가져옴
-                    .filter(dto -> dto != null && !dto.getAvailableRatePlans().isEmpty()) // 판매 가능한 요금제가 하나라도 있는 경우만 필터링
-                    .collect(Collectors.toList());
-
+        // 호텔이 판매 중이지 않으면 빈 결과 반환
+        if (!hotel.isOnSale()) {
             return AvailabilityResponse.builder()
                     .hotelId(hotel.getId())
                     .hotelName(hotel.getName())
                     .checkInDate(request.getCheckInDate())
                     .checkOutDate(request.getCheckOutDate())
-                    .availableRoomTypes(availableRoomTypes)
+                    .availableRoomTypes(List.of())
                     .build();
-        });
-    }
-
-    /**
-     * RoomType 엔터티를 AvailableRoomTypeDto로 변환하고 예약 가능성을 확인합니다.
-     *
-     * <p>이 메서드는 다음과 같은 작업을 수행합니다:</p>
-     * <ul>
-     *   <li>숙박 기간 동안의 최소 가용 객실 수 계산</li>
-     *   <li>객실 타입에 연결된 모든 요금제의 판매 가능 여부 확인</li>
-     *   <li>판매 가능한 요금제별 총 숙박비 계산</li>
-     * </ul>
-     *
-     * @param roomType 변환할 객실 타입 엔터티
-     * @param checkInDate 체크인 날짜
-     * @param checkOutDate 체크아웃 날짜
-     * @return 예약 가능한 경우 AvailableRoomTypeDto, 불가능한 경우 null
-     */
-    @Async
-    protected CompletableFuture<AvailableRoomTypeDto> toAvailableRoomTypeDtoAsync(RoomType roomType, LocalDate checkInDate, LocalDate checkOutDate) {
-        List<LocalDate> dates = checkInDate.datesUntil(checkOutDate).collect(Collectors.toList());
-
-        int minAvailableRooms = getMinimumAvailableRooms(roomType, dates);
-        if (minAvailableRooms <= 0) {
-            return null;
         }
 
-        List<AvailableRatePlanDto> availableRatePlans = roomType.getRatePlans().stream()
-                .filter(ratePlan -> ratePlan.isAvailableFor(checkInDate, checkOutDate))
-                .map(ratePlan -> {
-                    try {
-                        BigDecimal totalPrice = calculateTotalPriceForPlan(ratePlan, dates);
-                        return AvailableRatePlanDto.builder()
-                                .ratePlanId(ratePlan.getId())
-                                .ratePlanName(ratePlan.getName())
-                                .totalPrice(totalPrice)
-                                .build();
-                    } catch (BaseRateNotFoundException e) {
-                        log.warn("객실 타입 [{}(id:{})]의 요금제 [{}(id:{})]는 기본 요금이 없어 판매 불가합니다.",
-                                roomType.getName(),
-                                roomType.getId(),
-                                ratePlan.getName(),
-                                ratePlan.getId());
-                        return null;
-                    }
-                })
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+        List<RoomType> roomTypes = roomTypeRepository.findByHotelIdWithRatePlans(hotelId);
+        List<RatePlan> ratePlans = roomTypes.stream()
+                .flatMap(rt -> rt.getRatePlans().stream())
+                .toList();
 
-        var dto = AvailableRoomTypeDto.builder()
-                .roomTypeId(roomType.getId())
-                .roomTypeName(roomType.getName())
-                .standardCapacity(roomType.getStandardCapacity())
-                .maxCapacity(roomType.getMaxCapacity())
-                .remainingRooms(minAvailableRooms)
-                .availableRatePlans(availableRatePlans) // 3. 계산된 요금제 목록을 DTO에 담는다.
+        List<LocalDate> stayDates = request.getCheckInDate().datesUntil(request.getCheckOutDate()).toList();
+
+        // 숙박 기간에 해당하는 객실 재고, 기본 요금, 가격 조정 데이터를 모두 가져온 뒤 Id로 그룹화합니다.
+        Map<Long, List<RoomInventory>> inventoriesByRoomType = roomInventoryRepository
+                .findByRoomTypeInAndDateIn(roomTypes, stayDates)
+                .stream()
+                .collect(Collectors.groupingBy(ri -> ri.getRoomType().getId()));
+
+        Map<Long, List<BaseRate>> baseRatesByRatePlan = baseRateRepository
+                .findByRatePlanInAndDateIn(ratePlans, stayDates)
+                .stream()
+                .collect(Collectors.groupingBy(br -> br.getRatePlan().getId()));
+
+        Map<Long, List<PriceAdjustment>> adjustmentsByRatePlan = priceAdjustmentRepository
+                .findActiveAdjustmentsByRatePlanInDateRange(
+                        ratePlans,
+                        stayDates.get(0),
+                        stayDates.get(stayDates.size() - 1))
+                .stream()
+                .collect(Collectors.groupingBy(pa -> pa.getRatePlan().getId()));
+
+        List<AvailableRoomTypeDto> availableRoomTypes = new ArrayList<>();
+
+        for (RoomType roomType : roomTypes) {
+            // 객실이 판매 중인지, 인원수 조건에 맞는지 확인
+            if (!roomType.isOnSale() || !roomType.validateCapacity(request.getAdults(), request.getChildren())) {
+                continue;
+            }
+
+            // 해당 객실 타입의 숙박 기간 중 최소 재고 수량 확인
+            List<RoomInventory> inventories = inventoriesByRoomType.getOrDefault(roomType.getId(), List.of());
+            int minAvailableRooms = getMinimumAvailableRooms(inventories, stayDates);
+            if (minAvailableRooms <= 0) {
+                continue;
+            }
+
+            // 이 객실 타입의 각 요금제별로 판매 조건 확인 및 총 숙박비 계산
+            List<AvailableRatePlanDto> availableRatePlans = new ArrayList<>();
+            for (RatePlan ratePlan : roomType.getRatePlans()) {
+                // 숙박 기간이 요금제의 판매 조건에 맞는지 확인
+                if (!ratePlan.isAvailableFor(request.getCheckInDate(), request.getCheckOutDate())) {
+                    continue;
+                }
+
+                List<BaseRate> baseRates = baseRatesByRatePlan.getOrDefault(ratePlan.getId(), List.of());
+                List<PriceAdjustment> adjustments = adjustmentsByRatePlan.getOrDefault(ratePlan.getId(), List.of());
+
+                // 이 요금제의 총 숙박비 계산
+                try {
+                    BigDecimal totalPrice = calculateTotalPriceForPlan(baseRates, adjustments, stayDates);
+                    var availableRatePlanDto = AvailableRatePlanDto.builder()
+                            .ratePlanId(ratePlan.getId())
+                            .ratePlanName(ratePlan.getName())
+                            .totalPrice(totalPrice)
+                            .build();
+                    availableRatePlans.add(availableRatePlanDto);
+                } catch (BaseRateNotFoundException e) {
+                    log.warn("객실 타입 [{}(id:{})]의 요금제 [{}(id:{})]는 기본 요금이 없어 판매 불가합니다.",
+                            roomType.getName(),
+                            roomType.getId(),
+                            ratePlan.getName(),
+                            ratePlan.getId());
+                }
+            }
+
+            // 이 객실 타입에 예약 가능한 요금제가 하나도 없으면 제외
+            if (availableRatePlans.isEmpty()) {
+                continue;
+            }
+            var availableRoomTypeDto = AvailableRoomTypeDto.builder()
+                    .roomTypeId(roomType.getId())
+                    .roomTypeName(roomType.getName())
+                    .standardCapacity(roomType.getStandardCapacity())
+                    .maxCapacity(roomType.getMaxCapacity())
+                    .remainingRooms(minAvailableRooms)
+                    .availableRatePlans(availableRatePlans)
+                    .build();
+            availableRoomTypes.add(availableRoomTypeDto);
+        }
+
+        return AvailabilityResponse.builder()
+                .hotelId(hotel.getId())
+                .hotelName(hotel.getName())
+                .checkInDate(request.getCheckInDate())
+                .checkOutDate(request.getCheckOutDate())
+                .availableRoomTypes(availableRoomTypes)
                 .build();
-        return CompletableFuture.completedFuture(dto);
-    }
-
-    /**
-     * 특정 요금제에 대해 숙박 기간 전체의 총 요금을 계산합니다.
-     *
-     * <p>요금 계산 프로세스:</p>
-     * <ol>
-     *   <li>숙박 기간 중 각 날짜별 기본 요금 조회</li>
-     *   <li>해당 요금제에 적용 가능한 모든 가격 조정(할인/할증) 항목 조회</li>
-     *   <li>각 날짜별로 기본 요금 + 가격 조정을 적용하여 최종 일일 요금 계산</li>
-     *   <li>모든 일일 요금을 합산하여 총 숙박비 반환</li>
-     * </ol>
-     *
-     * <p>가격 조정에는 다음과 같은 유형이 있습니다:</p>
-     * <ul>
-     *   <li>얼리버드 할인 (예약일 기준)</li>
-     *   <li>시즌 할인/할증 (숙박일 기준)</li>
-     *   <li>고정 금액 할인/할증</li>
-     *   <li>퍼센트 할인/할증</li>
-     * </ul>
-     *
-     * @param ratePlan 요금을 계산할 요금제
-     * @param dates 숙박 기간의 날짜 목록 (체크인 ~ 체크아웃-1)
-     * @return 총 숙박 요금
-     * @throws BaseRateNotFoundException 특정 날짜의 기본 요금이 존재하지 않는 경우
-     */
-    private BigDecimal calculateTotalPriceForPlan(RatePlan ratePlan, List<LocalDate> dates) {
-        // 1. DB 조회 최소화를 위해 필요한 데이터를 미리 한 번에 가져옵니다.
-        final List<BaseRate> baseRates = baseRateRepository.findByRatePlanAndDateIn(ratePlan, dates);
-        final List<PriceAdjustment> adjustments = priceAdjustmentRepository.findActiveAdjustmentsForPlanInDateRange(
-                ratePlan, dates.get(0), dates.get(dates.size() - 1)
-        );
-
-        BigDecimal totalPrice = BigDecimal.ZERO;
-        final LocalDate today = LocalDate.now();
-
-        // 2. 하루씩 순회하며 일별 최종 요금을 계산하고 합산합니다.
-        for (LocalDate date : dates) {
-            // 해당 날짜의 기본 요금을 찾습니다.
-            BigDecimal dailyBasePrice = baseRates.stream()
-                    .filter(br -> br.getDate().equals(date))
-                    .findFirst()
-                    .orElseThrow(() -> new BaseRateNotFoundException(date))
-                    .getPrice();
-
-            // 기본 요금에 적용 가능한 모든 조정 항목(할인/할증)을 반영합니다.
-            BigDecimal finalDailyPrice = applyAdjustments(dailyBasePrice, date, today, adjustments);
-
-            totalPrice = totalPrice.add(finalDailyPrice);
-        }
-        return totalPrice;
-    }
-
-    /**
-     * 숙박 기간 동안 해당 객실 타입의 최소 가용 객실 수를 계산합니다.
-     *
-     * <p>이 메서드는 숙박 기간의 각 날짜별로 다음을 계산합니다:</p>
-     * <ul>
-     *   <li>전체 객실 수 - 이미 예약된 객실 수 = 가용 객실 수</li>
-     * </ul>
-     *
-     * <p>그 중에서 가장 적은 가용 객실 수를 반환하여,
-     * 숙박 기간 전체에 걸쳐 예약 가능한 최대 객실 수를 보장합니다.</p>
-     *
-     * @param roomType 확인할 객실 타입
-     * @param dates 확인할 날짜 목록
-     * @return 숙박 기간 중 최소 가용 객실 수 (모든 날짜의 재고 데이터가 없는 경우 0)
-     */
-    private int getMinimumAvailableRooms(RoomType roomType, List<LocalDate> dates) {
-        var inventories = roomInventoryRepository.findByRoomTypeAndDateIn(roomType, dates);
-        if (inventories.size() != dates.size()) { return 0; }
-        return inventories.stream()
-                .mapToInt(RoomInventory::getAvailableQuantity)
-                .min()
-                .orElse(0);
     }
 
     /**
@@ -298,5 +237,57 @@ public class AvailabilityService {
         }
         // 최종 금액이 음수가 되지 않도록 보정
         return finalPrice.compareTo(BigDecimal.ZERO) < 0 ? BigDecimal.ZERO : finalPrice;
+    }
+
+    /**
+     * 주어진 숙박 날짜들에 대해 각 날짜의 객실 재고 중 최소 재고 수량을 반환합니다.
+     *
+     * <p>재고 수량이 충분하지 않은 경우(재고 데이터가 없거나, 날짜 수와 재고 데이터 수가 일치하지 않는 경우) 0을 반환합니다.</p>
+     *
+     * @param inventories 객실 타입과 숙박 날짜에 해당하는 재고 목록
+     * @param stayDates 조회 대상 숙박 날짜 목록
+     * @return 숙박 기간 중 최소 재고 수량 (0 이상)
+     */
+    private int getMinimumAvailableRooms(List<RoomInventory> inventories, List<LocalDate> stayDates) {
+        if (inventories.size() != stayDates.size()) { return 0; }
+        return inventories.stream()
+                .mapToInt(RoomInventory::getAvailableQuantity)
+                .min()
+                .orElse(0);
+    }
+
+    /**
+     * 특정 요금제에 대해 숙박 기간 동안의 총 요금을 계산합니다.
+     *
+     * <p>계산 로직:</p>
+     * <ol>
+     *   <li>숙박 날짜별로 기본 요금을 조회</li>
+     *   <li>각 날짜별로 적용 가능한 가격 조정을 반영하여 최종 일일 요금 계산</li>
+     *   <li>모든 숙박 날짜의 최종 일일 요금을 합산하여 총 요금 산출</li>
+     * </ol>
+     *
+     * @param baseRates 해당 요금제의 기본 요금 목록 (숙박 날짜에 해당하는 데이터만 포함)
+     * @param adjustments 해당 요금제에 적용 가능한 가격 조정 목록 (숙박 기간에 해당하는 데이터만 포함)
+     * @param stayDates 숙박 날짜 목록
+     * @return 숙박 기간 동안의 총 요금
+     * @throws BaseRateNotFoundException 숙박 날짜 중 하나라도 기본 요금이 없는 경우
+     */
+    private BigDecimal calculateTotalPriceForPlan(List<BaseRate> baseRates, List<PriceAdjustment> adjustments, List<LocalDate> stayDates) {
+        BigDecimal totalPrice = BigDecimal.ZERO;
+        LocalDate today = LocalDate.now();
+
+        for (LocalDate stayDate : stayDates) {
+            BigDecimal dailyBasePrice = baseRates.stream()
+                    .filter(br -> br.getDate().equals(stayDate))
+                    .findFirst()
+                    .orElseThrow(() -> new BaseRateNotFoundException(stayDate))
+                    .getPrice();
+
+            BigDecimal finalDailyPrice = applyAdjustments(dailyBasePrice, stayDate, today, adjustments);
+
+            totalPrice = totalPrice.add(finalDailyPrice);
+        }
+
+        return totalPrice;
     }
 }

--- a/service/hotel-service/src/test/java/dev/muho/hotel/service/AvailabilityServiceTest.java
+++ b/service/hotel-service/src/test/java/dev/muho/hotel/service/AvailabilityServiceTest.java
@@ -35,6 +35,8 @@ public class AvailabilityServiceTest {
     @Mock
     private HotelRepository hotelRepository;
     @Mock
+    private RoomTypeRepository roomTypeRepository;
+    @Mock
     private RoomInventoryRepository roomInventoryRepository;
     @Mock
     private BaseRateRepository baseRateRepository;
@@ -59,32 +61,29 @@ public class AvailabilityServiceTest {
         ReflectionTestUtils.setField(roomType, "id", 1L);
         ReflectionTestUtils.setField(roomType, "ratePlans", List.of(ratePlan));
 
-        ReflectionTestUtils.setField(hotel, "roomTypes", List.of(roomType));
-
         // 재고 설정 (2일 모두 5개씩 재고 있음)
-        RoomInventory inventory1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).build();
+        RoomInventory inventory1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).roomType(roomType).build();
         ReflectionTestUtils.setField(inventory1, "reservedQuantity", 5);
-
-        RoomInventory inventory2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(10).build();
+        RoomInventory inventory2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(10).roomType(roomType).build();
         ReflectionTestUtils.setField(inventory2, "reservedQuantity", 5);
-
         List<RoomInventory> inventories = List.of(inventory1, inventory2);
 
         // 요금 설정 (1박에 100,000원)
         List<BaseRate> baseRates = List.of(
-                BaseRate.builder().date(dates.get(0)).price(new BigDecimal("100000")).build(),
-                BaseRate.builder().date(dates.get(1)).price(new BigDecimal("100000")).build()
+                BaseRate.builder().date(dates.get(0)).price(new BigDecimal("100000")).ratePlan(ratePlan).build(),
+                BaseRate.builder().date(dates.get(1)).price(new BigDecimal("100000")).ratePlan(ratePlan).build()
         );
 
         // Repository Mocking
         when(hotelRepository.findById(1L)).thenReturn(Optional.of(hotel));
-        when(roomInventoryRepository.findByRoomTypeAndDateIn(roomType, dates)).thenReturn(inventories);
-        when(baseRateRepository.findByRatePlanAndDateIn(ratePlan, dates)).thenReturn(baseRates);
-        when(priceAdjustmentRepository.findActiveAdjustmentsForPlanInDateRange(any(), any(), any())).thenReturn(Collections.emptyList());
+        when(roomTypeRepository.findByHotelIdWithRatePlans(1L)).thenReturn(List.of(roomType));
+        when(roomInventoryRepository.findByRoomTypeInAndDateIn(List.of(roomType), dates)).thenReturn(inventories);
+        when(baseRateRepository.findByRatePlanInAndDateIn(List.of(ratePlan), dates)).thenReturn(baseRates);
+        when(priceAdjustmentRepository.findActiveAdjustmentsByRatePlanInDateRange(any(), any(), any())).thenReturn(Collections.emptyList());
 
         // when (실제 테스트할 메서드 호출)
         AvailabilityRequest request = new AvailabilityRequest(checkIn, checkOut, 2, 0);
-        AvailabilityResponse response = availabilityService.checkAvailabilityAsync(1L, request).join();
+        AvailabilityResponse response = availabilityService.checkAvailability(1L, request);
 
         // then (결과 검증)
         assertThat(response.getAvailableRoomTypes()).hasSize(1);
@@ -114,21 +113,21 @@ public class AvailabilityServiceTest {
         ReflectionTestUtils.setField(hotel, "roomTypes", List.of(roomType));
 
         // 재고 설정 (하루는 5개, 하루는 0개)
-        RoomInventory inventory1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).build();
+        RoomInventory inventory1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).roomType(roomType).build();
         ReflectionTestUtils.setField(inventory1, "reservedQuantity", 5);
-
-        RoomInventory inventory2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(10).build();
+        RoomInventory inventory2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(10).roomType(roomType).build();
         ReflectionTestUtils.setField(inventory2, "reservedQuantity", 10);
 
         List<RoomInventory> inventories = List.of(inventory1, inventory2);
 
         // Repository Mocking
         when(hotelRepository.findById(1L)).thenReturn(Optional.of(hotel));
-        when(roomInventoryRepository.findByRoomTypeAndDateIn(roomType, dates)).thenReturn(inventories);
+        when(roomTypeRepository.findByHotelIdWithRatePlans(1L)).thenReturn(List.of(roomType));
+        when(roomInventoryRepository.findByRoomTypeInAndDateIn(List.of(roomType), dates)).thenReturn(inventories);
 
         // when
         AvailabilityRequest request = new AvailabilityRequest(checkIn, checkOut, 2, 0);
-        AvailabilityResponse response = availabilityService.checkAvailabilityAsync(1L, request).join();
+        AvailabilityResponse response = availabilityService.checkAvailability(1L, request);
 
         // then
         assertThat(response.getAvailableRoomTypes()).isEmpty();
@@ -144,7 +143,7 @@ public class AvailabilityServiceTest {
         LocalDate checkIn = TestDateUtils.getFutureLocalDatePlusDays(30);
         LocalDate checkOut = TestDateUtils.getFutureLocalDatePlusDays(32);
         AvailabilityRequest request = new AvailabilityRequest(checkIn, checkOut, 2, 0);
-        assertThatThrownBy(() -> availabilityService.checkAvailabilityAsync(999L, request).join())
+        assertThatThrownBy(() -> availabilityService.checkAvailability(999L, request))
                 .isInstanceOf(HotelNotFoundException.class)
                 .hasMessage("존재하지 않는 호텔입니다.");
     }
@@ -169,7 +168,7 @@ public class AvailabilityServiceTest {
 
         // when (성인 2명 + 아동 2명 = 총 4명, 객실 수용 인원 2명 초과)
         AvailabilityRequest request = new AvailabilityRequest(checkIn, checkOut, 2, 2);
-        AvailabilityResponse response = availabilityService.checkAvailabilityAsync(1L, request).join();
+        AvailabilityResponse response = availabilityService.checkAvailability(1L, request);
 
         // then
         assertThat(response.getAvailableRoomTypes()).isEmpty();
@@ -198,17 +197,18 @@ public class AvailabilityServiceTest {
         ReflectionTestUtils.setField(hotel, "roomTypes", List.of(roomType));
 
         // 재고는 충분
-        RoomInventory inventory1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).build();
+        RoomInventory inventory1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).roomType(roomType).build();
         ReflectionTestUtils.setField(inventory1, "reservedQuantity", 5);
-        RoomInventory inventory2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(10).build();
+        RoomInventory inventory2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(10).roomType(roomType).build();
         ReflectionTestUtils.setField(inventory2, "reservedQuantity", 5);
 
         when(hotelRepository.findById(1L)).thenReturn(Optional.of(hotel));
-        when(roomInventoryRepository.findByRoomTypeAndDateIn(roomType, dates)).thenReturn(List.of(inventory1, inventory2));
+        when(roomTypeRepository.findByHotelIdWithRatePlans(1L)).thenReturn(List.of(roomType));
+        when(roomInventoryRepository.findByRoomTypeInAndDateIn(List.of(roomType), dates)).thenReturn(List.of(inventory1, inventory2));
 
         // when
         AvailabilityRequest request = new AvailabilityRequest(checkIn, checkOut, 2, 0);
-        AvailabilityResponse response = availabilityService.checkAvailabilityAsync(1L, request).join();
+        AvailabilityResponse response = availabilityService.checkAvailability(1L, request);
 
         // then
         assertThat(response.getAvailableRoomTypes()).isEmpty();
@@ -236,15 +236,16 @@ public class AvailabilityServiceTest {
         ReflectionTestUtils.setField(hotel, "roomTypes", List.of(roomType));
 
         // 재고는 충분
-        RoomInventory inventory = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).build();
+        RoomInventory inventory = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).roomType(roomType).build();
         ReflectionTestUtils.setField(inventory, "reservedQuantity", 5);
 
         when(hotelRepository.findById(1L)).thenReturn(Optional.of(hotel));
-        when(roomInventoryRepository.findByRoomTypeAndDateIn(roomType, dates)).thenReturn(List.of(inventory));
+        when(roomTypeRepository.findByHotelIdWithRatePlans(1L)).thenReturn(List.of(roomType));
+        when(roomInventoryRepository.findByRoomTypeInAndDateIn(List.of(roomType), dates)).thenReturn(List.of(inventory));
 
         // when
         AvailabilityRequest request = new AvailabilityRequest(checkIn, checkOut, 2, 0);
-        AvailabilityResponse response = availabilityService.checkAvailabilityAsync(1L, request).join();
+        AvailabilityResponse response = availabilityService.checkAvailability(1L, request);
 
         // then
         assertThat(response.getAvailableRoomTypes()).isEmpty();
@@ -274,18 +275,19 @@ public class AvailabilityServiceTest {
         // 재고는 모든 날짜에 충분
         List<RoomInventory> inventories = dates.stream()
                 .map(date -> {
-                    RoomInventory inventory = RoomInventory.builder().date(date).totalQuantity(10).build();
+                    RoomInventory inventory = RoomInventory.builder().date(date).totalQuantity(10).roomType(roomType).build();
                     ReflectionTestUtils.setField(inventory, "reservedQuantity", 5);
                     return inventory;
                 })
                 .toList();
 
         when(hotelRepository.findById(1L)).thenReturn(Optional.of(hotel));
-        when(roomInventoryRepository.findByRoomTypeAndDateIn(roomType, dates)).thenReturn(inventories);
+        when(roomTypeRepository.findByHotelIdWithRatePlans(1L)).thenReturn(List.of(roomType));
+        when(roomInventoryRepository.findByRoomTypeInAndDateIn(List.of(roomType), dates)).thenReturn(inventories);
 
         // when
         AvailabilityRequest request = new AvailabilityRequest(checkIn, checkOut, 2, 0);
-        AvailabilityResponse response = availabilityService.checkAvailabilityAsync(1L, request).join();
+        AvailabilityResponse response = availabilityService.checkAvailability(1L, request);
 
         // then
         assertThat(response.getAvailableRoomTypes()).isEmpty();
@@ -314,13 +316,15 @@ public class AvailabilityServiceTest {
         // 재고 설정
         RoomInventory inventory1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).build();
         ReflectionTestUtils.setField(inventory1, "reservedQuantity", 5);
+        ReflectionTestUtils.setField(inventory1, "roomType", roomType);
         RoomInventory inventory2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(10).build();
         ReflectionTestUtils.setField(inventory2, "reservedQuantity", 5);
+        ReflectionTestUtils.setField(inventory2, "roomType", roomType);
 
         // 기본 요금 설정 (1박에 100,000원)
         List<BaseRate> baseRates = List.of(
-                BaseRate.builder().date(dates.get(0)).price(new BigDecimal("100000")).build(),
-                BaseRate.builder().date(dates.get(1)).price(new BigDecimal("100000")).build()
+                BaseRate.builder().date(dates.get(0)).price(new BigDecimal("100000")).ratePlan(ratePlan).build(),
+                BaseRate.builder().date(dates.get(1)).price(new BigDecimal("100000")).ratePlan(ratePlan).build()
         );
 
         // 10% 할인 설정
@@ -331,16 +335,18 @@ public class AvailabilityServiceTest {
                 .amount(new BigDecimal("10"))
                 .calculationType(CalculationType.PERCENTAGE)
                 .adjustmentType(AdjustmentType.DISCOUNT)
+                .ratePlan(ratePlan)
                 .build();
 
         when(hotelRepository.findById(1L)).thenReturn(Optional.of(hotel));
-        when(roomInventoryRepository.findByRoomTypeAndDateIn(roomType, dates)).thenReturn(List.of(inventory1, inventory2));
-        when(baseRateRepository.findByRatePlanAndDateIn(ratePlan, dates)).thenReturn(baseRates);
-        when(priceAdjustmentRepository.findActiveAdjustmentsForPlanInDateRange(any(), any(), any())).thenReturn(List.of(discount));
+        when(roomTypeRepository.findByHotelIdWithRatePlans(1L)).thenReturn(List.of(roomType));
+        when(roomInventoryRepository.findByRoomTypeInAndDateIn(List.of(roomType), dates)).thenReturn(List.of(inventory1, inventory2));
+        when(baseRateRepository.findByRatePlanInAndDateIn(List.of(ratePlan), dates)).thenReturn(baseRates);
+        when(priceAdjustmentRepository.findActiveAdjustmentsByRatePlanInDateRange(any(), any(), any())).thenReturn(List.of(discount));
 
         // when
         AvailabilityRequest request = new AvailabilityRequest(checkIn, checkOut, 2, 0);
-        AvailabilityResponse response = availabilityService.checkAvailabilityAsync(1L, request).join();
+        AvailabilityResponse response = availabilityService.checkAvailability(1L, request);
 
         // then
         assertThat(response.getAvailableRoomTypes()).hasSize(1);
@@ -372,15 +378,15 @@ public class AvailabilityServiceTest {
         ReflectionTestUtils.setField(hotel, "roomTypes", List.of(roomType));
 
         // 재고 설정
-        RoomInventory inventory1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).build();
+        RoomInventory inventory1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).roomType(roomType).build();
         ReflectionTestUtils.setField(inventory1, "reservedQuantity", 5);
-        RoomInventory inventory2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(10).build();
+        RoomInventory inventory2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(10).roomType(roomType).build();
         ReflectionTestUtils.setField(inventory2, "reservedQuantity", 5);
 
         // 기본 요금 설정 (1박에 100,000원)
         List<BaseRate> baseRates = List.of(
-                BaseRate.builder().date(dates.get(0)).price(new BigDecimal("100000")).build(),
-                BaseRate.builder().date(dates.get(1)).price(new BigDecimal("100000")).build()
+                BaseRate.builder().date(dates.get(0)).price(new BigDecimal("100000")).ratePlan(ratePlan).build(),
+                BaseRate.builder().date(dates.get(1)).price(new BigDecimal("100000")).ratePlan(ratePlan).build()
         );
 
         // 고정 금액 20,000원 할증 설정
@@ -391,16 +397,18 @@ public class AvailabilityServiceTest {
                 .amount(new BigDecimal("20000"))
                 .calculationType(CalculationType.FIXED_AMOUNT)
                 .adjustmentType(AdjustmentType.SURCHARGE)
+                .ratePlan(ratePlan)
                 .build();
 
         when(hotelRepository.findById(1L)).thenReturn(Optional.of(hotel));
-        when(roomInventoryRepository.findByRoomTypeAndDateIn(roomType, dates)).thenReturn(List.of(inventory1, inventory2));
-        when(baseRateRepository.findByRatePlanAndDateIn(ratePlan, dates)).thenReturn(baseRates);
-        when(priceAdjustmentRepository.findActiveAdjustmentsForPlanInDateRange(any(), any(), any())).thenReturn(List.of(surcharge));
+        when(roomTypeRepository.findByHotelIdWithRatePlans(1L)).thenReturn(List.of(roomType));
+        when(roomInventoryRepository.findByRoomTypeInAndDateIn(List.of(roomType), dates)).thenReturn(List.of(inventory1, inventory2));
+        when(baseRateRepository.findByRatePlanInAndDateIn(List.of(ratePlan), dates)).thenReturn(baseRates);
+        when(priceAdjustmentRepository.findActiveAdjustmentsByRatePlanInDateRange(any(), any(), any())).thenReturn(List.of(surcharge));
 
         // when
         AvailabilityRequest request = new AvailabilityRequest(checkIn, checkOut, 2, 0);
-        AvailabilityResponse response = availabilityService.checkAvailabilityAsync(1L, request).join();
+        AvailabilityResponse response = availabilityService.checkAvailability(1L, request);
 
         // then
         assertThat(response.getAvailableRoomTypes()).hasSize(1);
@@ -440,37 +448,36 @@ public class AvailabilityServiceTest {
         ReflectionTestUtils.setField(hotel, "roomTypes", List.of(roomType1, roomType2));
 
         // 첫 번째 객실 타입 재고
-        RoomInventory inventory1_1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).build();
+        RoomInventory inventory1_1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).roomType(roomType1).build();
         ReflectionTestUtils.setField(inventory1_1, "reservedQuantity", 5);
-        RoomInventory inventory1_2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(10).build();
+        RoomInventory inventory1_2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(10).roomType(roomType1).build();
         ReflectionTestUtils.setField(inventory1_2, "reservedQuantity", 5);
 
         // 두 번째 객실 타입 재고
-        RoomInventory inventory2_1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(5).build();
+        RoomInventory inventory2_1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(5).roomType(roomType2).build();
         ReflectionTestUtils.setField(inventory2_1, "reservedQuantity", 2);
-        RoomInventory inventory2_2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(5).build();
+        RoomInventory inventory2_2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(5).roomType(roomType2).build();
         ReflectionTestUtils.setField(inventory2_2, "reservedQuantity", 2);
 
         // 기본 요금 설정
         List<BaseRate> baseRates1 = List.of(
-                BaseRate.builder().date(dates.get(0)).price(new BigDecimal("100000")).build(),
-                BaseRate.builder().date(dates.get(1)).price(new BigDecimal("100000")).build()
+                BaseRate.builder().date(dates.get(0)).price(new BigDecimal("100000")).ratePlan(ratePlan1).build(),
+                BaseRate.builder().date(dates.get(1)).price(new BigDecimal("100000")).ratePlan(ratePlan1).build()
         );
         List<BaseRate> baseRates2 = List.of(
-                BaseRate.builder().date(dates.get(0)).price(new BigDecimal("150000")).build(),
-                BaseRate.builder().date(dates.get(1)).price(new BigDecimal("150000")).build()
+                BaseRate.builder().date(dates.get(0)).price(new BigDecimal("150000")).ratePlan(ratePlan2).build(),
+                BaseRate.builder().date(dates.get(1)).price(new BigDecimal("150000")).ratePlan(ratePlan2).build()
         );
 
         when(hotelRepository.findById(1L)).thenReturn(Optional.of(hotel));
-        when(roomInventoryRepository.findByRoomTypeAndDateIn(roomType1, dates)).thenReturn(List.of(inventory1_1, inventory1_2));
-        when(roomInventoryRepository.findByRoomTypeAndDateIn(roomType2, dates)).thenReturn(List.of(inventory2_1, inventory2_2));
-        when(baseRateRepository.findByRatePlanAndDateIn(ratePlan1, dates)).thenReturn(baseRates1);
-        when(baseRateRepository.findByRatePlanAndDateIn(ratePlan2, dates)).thenReturn(baseRates2);
-        when(priceAdjustmentRepository.findActiveAdjustmentsForPlanInDateRange(any(), any(), any())).thenReturn(Collections.emptyList());
+        when(roomTypeRepository.findByHotelIdWithRatePlans(1L)).thenReturn(List.of(roomType1, roomType2));
+        when(roomInventoryRepository.findByRoomTypeInAndDateIn(List.of(roomType1, roomType2), dates)).thenReturn(List.of(inventory1_1, inventory1_2, inventory2_1, inventory2_2));
+        when(baseRateRepository.findByRatePlanInAndDateIn(List.of(ratePlan1, ratePlan2), dates)).thenReturn(List.of(baseRates1.get(0), baseRates2.get(0), baseRates1.get(1), baseRates2.get(1)));
+        when(priceAdjustmentRepository.findActiveAdjustmentsByRatePlanInDateRange(any(), any(), any())).thenReturn(Collections.emptyList());
 
         // when
         AvailabilityRequest request = new AvailabilityRequest(checkIn, checkOut, 2, 0);
-        AvailabilityResponse response = availabilityService.checkAvailabilityAsync(1L, request).join();
+        AvailabilityResponse response = availabilityService.checkAvailability(1L, request);
 
         // then
         assertThat(response.getAvailableRoomTypes()).hasSize(2);
@@ -502,7 +509,6 @@ public class AvailabilityServiceTest {
         // 예약 기간이 지난 요금제 (예약 마감일이 과거)
         RatePlan ratePlan = RatePlan.builder()
                 .name("마감된 플랜")
-                
                 .minNights(1)
                 .bookingStartDate(TestDateUtils.getFutureLocalDatePlusDays(-60))
                 .bookingEndDate(TestDateUtils.getFutureLocalDatePlusDays(-30)) // 예약 마감일이 과거
@@ -516,17 +522,18 @@ public class AvailabilityServiceTest {
         ReflectionTestUtils.setField(hotel, "roomTypes", List.of(roomType));
 
         // 재고는 충분
-        RoomInventory inventory1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).build();
+        RoomInventory inventory1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).roomType(roomType).build();
         ReflectionTestUtils.setField(inventory1, "reservedQuantity", 5);
-        RoomInventory inventory2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(10).build();
+        RoomInventory inventory2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(10).roomType(roomType).build();
         ReflectionTestUtils.setField(inventory2, "reservedQuantity", 5);
 
         when(hotelRepository.findById(1L)).thenReturn(Optional.of(hotel));
-        when(roomInventoryRepository.findByRoomTypeAndDateIn(roomType, dates)).thenReturn(List.of(inventory1, inventory2));
+        when(roomTypeRepository.findByHotelIdWithRatePlans(1L)).thenReturn(List.of(roomType));
+        when(roomInventoryRepository.findByRoomTypeInAndDateIn(List.of(roomType), dates)).thenReturn(List.of(inventory1, inventory2));
 
         // when
         AvailabilityRequest request = new AvailabilityRequest(checkIn, checkOut, 2, 0);
-        AvailabilityResponse response = availabilityService.checkAvailabilityAsync(1L, request).join();
+        AvailabilityResponse response = availabilityService.checkAvailability(1L, request);
 
         // then
         assertThat(response.getAvailableRoomTypes()).isEmpty();
@@ -560,17 +567,18 @@ public class AvailabilityServiceTest {
         ReflectionTestUtils.setField(hotel, "roomTypes", List.of(roomType));
 
         // 재고는 충분
-        RoomInventory inventory1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).build();
+        RoomInventory inventory1 = RoomInventory.builder().date(dates.get(0)).totalQuantity(10).roomType(roomType).build();
         ReflectionTestUtils.setField(inventory1, "reservedQuantity", 5);
-        RoomInventory inventory2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(10).build();
+        RoomInventory inventory2 = RoomInventory.builder().date(dates.get(1)).totalQuantity(10).roomType(roomType).build();
         ReflectionTestUtils.setField(inventory2, "reservedQuantity", 5);
 
         when(hotelRepository.findById(1L)).thenReturn(Optional.of(hotel));
-        when(roomInventoryRepository.findByRoomTypeAndDateIn(roomType, dates)).thenReturn(List.of(inventory1, inventory2));
+        when(roomTypeRepository.findByHotelIdWithRatePlans(1L)).thenReturn(List.of(roomType));
+        when(roomInventoryRepository.findByRoomTypeInAndDateIn(List.of(roomType), dates)).thenReturn(List.of(inventory1, inventory2));
 
         // when
         AvailabilityRequest request = new AvailabilityRequest(checkIn, checkOut, 2, 0);
-        AvailabilityResponse response = availabilityService.checkAvailabilityAsync(1L, request).join();
+        AvailabilityResponse response = availabilityService.checkAvailability(1L, request);
 
         // then
         assertThat(response.getAvailableRoomTypes()).isEmpty();


### PR DESCRIPTION
## 컨트롤러 비동기화

- 톰캣 스레드의 빠른 회수를 위한 컨트롤러 메서드 비동기화 (`Completable.supplyAsync` 사용), 그리고 별도의 스레드 풀을 사용하도록 설정
- 비즈니스 로직을 담당하는 서비스 메서드는 동기 로직으로 변경
- 이전의 `@Async` 어노테이션 제거

## DB 최적화

- JPA 엔터티의 지연 로딩으로 인한 N+1 문제 해결
- `@EntityGrpah`를 이용하여 `RoomType` 조회 시 `RatePlan`까지 함께 조회
- `in` 쿼리를 사용하여 각각 DB 조회 요청 1번에 필요한 모든 데이터를 조회 (`RoomInventory`, `BaseRate`, `PriceAdjustment`)